### PR TITLE
feat(api): implement user-controlled livestream toggle endpoint with …

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -36,6 +36,7 @@ Route::post('fetchUsersByCordinates', [UsersController::class, 'fetchUsersByCord
 Route::post('updateUserBlockList', [UsersController::class, 'updateUserBlockList'])->middleware('checkHeader');
 Route::post('deleteMyAccount', [UsersController::class, 'deleteMyAccount'])->middleware('checkHeader');
 Route::post('minusCoinsFromWallet', [UsersController::class, 'minusCoinsFromWallet'])->middleware('checkHeader');
+Route::post('toggleLiveStreamStatus', [UsersController::class, 'toggleLiveStreamStatus'])->middleware('checkHeader');
 
 Route::post('getProfile', [UsersController::class, 'getProfile'])->middleware('checkHeader');
 Route::post('getUserDetails', [UsersController::class, 'getUserDetails'])->middleware('checkHeader');


### PR DESCRIPTION
…validation

- Add toggleLiveStreamStatus API endpoint for mobile user self-service
- Enable users to toggle their own livestream permissions without admin approval
- Implement toggle logic between enabled (2) and disabled (0) states
- Add comprehensive request validation with proper error responses
- Include detailed API response with user status and eligibility confirmation
- Support both enabling and disabling livestream permissions via single endpoint
- Update API routes with checkHeader middleware for authenticated access
- Maintain backward compatibility with existing admin livestream controls
- Set default can_go_live = 2 for new user registrations to enable immediate streaming
- Enhance user autonomy over livestream functionality and reduce admin overhead

🤖 Generated with [Claude Code](https://claude.ai/code)